### PR TITLE
Fixes extractQuerystring() throwing

### DIFF
--- a/srcs/request/HttpRequest.cpp
+++ b/srcs/request/HttpRequest.cpp
@@ -51,9 +51,15 @@ HTTPRequest::HTTPRequest(const std::string& request)
 
 void HTTPRequest::extractQueryString()
 {
-	_uriWithoutQString = _uri.substr(0, _uri.find_first_of('?'));
+	size_t	sepPos = _uri.find_first_of('?');
 
-	std::string queryStrs = _uri.substr(_uri.find_first_of('?'));
+	if (sepPos == std::string::npos)
+	{
+		_uriWithoutQString = _uri;
+		return ;
+	}
+	_uriWithoutQString = _uri.substr(0, sepPos);
+	std::string queryStrs = _uri.substr(sepPos, _uri.size());
 	if (queryStrs.length() > 0)
 		queryStrs.erase(0, 1);
 	while (queryStrs.length() > 0)


### PR DESCRIPTION
Add: check in extractQueryString() for separator before tokenizing, now returns early if no separators.

Fix: extractQueryString() not checking for separator before trying to extract query strings from uri.

Need to come back to this and test further for actual uris to make sure it still tokenizes correctly.