### PR TITLE
Fixes conditional jump in handleClientEvent and cleans up sockets properly when in bad state.

### DIFF
--- a/srcs/server/Server.cpp
+++ b/srcs/server/Server.cpp
@@ -160,8 +160,10 @@ void	Server::handleClientEvent(int clientSocket, uint32_t event)
 	sockaddr_in	cliAddr, srvAddr;
 	socklen_t	cliAddrLen = sizeof(cliAddr), srvAddrLen = sizeof(srvAddr);
 	char cliIP[16], srvIP[16];
-	getpeername(clientSocket, (sockaddr *)&cliAddr, &cliAddrLen);
-	getsockname(clientSocket, (sockaddr *)&srvAddr, &srvAddrLen);
+	if (getpeername(clientSocket, (sockaddr *)&cliAddr, &cliAddrLen) == -1)
+		return ;
+	if (getsockname(clientSocket, (sockaddr *)&srvAddr, &srvAddrLen) == -1)
+		return ;
 	inet_ntop(AF_INET, &cliAddr.sin_addr, cliIP, sizeof(cliIP));
 	inet_ntop(AF_INET, &srvAddr.sin_addr, srvIP, sizeof(srvIP));
 	std::cout << "handleClientEvent()  socket: " << clientSocket


### PR DESCRIPTION
Adds: infoStatus int storing return values of getpeername() and getsockname() in handleClientEvent(). This int is used to check for sockets in bad states, if the check fails, then we clean up the sockets as if the client had disconnected cleanly.

Fixes: valgrind errors when pressing down f5 in browser, but more generally, allows the  server to clean up bad sockets independently of what created them.