### PR TITLE
Bad Request error handling

### DIFF
--- a/configs/default.conf
+++ b/configs/default.conf
@@ -2,7 +2,7 @@
 server
 {
 	host = 0.0.0.0
-	port = 8085
+	port = 8080
 	server_name = localhost
 	root = www
 	autoindex = on

--- a/srcs/request/HttpRequest.cpp
+++ b/srcs/request/HttpRequest.cpp
@@ -56,6 +56,8 @@ HTTPRequest::HTTPRequest(const std::string& request, t_server &server): _server(
 	std::istringstream	lineStream(request_line);
 
 	lineStream >> _method >> _uri >> _httpVersion;
+	if (_method != "GET" && _method != "POST" && _method != "DELETE")
+		_method = "INVALID";
 	while (std::getline(stream, request_line) && request_line != "\r")
 	{
 		size_t	sepPos = request_line.find(':');

--- a/srcs/response/Response.cpp
+++ b/srcs/response/Response.cpp
@@ -225,7 +225,7 @@ OutgoingData * Response::handlePost(HTTPRequest & req, int clientSocket)
 		return cgi.handleCgi();
 	}
 	else if (contentType.empty())
-		return makeErrorResponse(404, "Not Found", server, clientSocket);
+		return makeErrorResponse(204, "No Content", server, clientSocket);
 	else if (contentType.find("text/plain") != std::string::npos)
 		return handleTextPost(req, maxBodySize);
 	else if (contentType.find("multipart/form-data") != std::string::npos)

--- a/srcs/response/Response.cpp
+++ b/srcs/response/Response.cpp
@@ -225,7 +225,7 @@ OutgoingData * Response::handlePost(HTTPRequest & req, int clientSocket)
 		return cgi.handleCgi();
 	}
 	else if (contentType.empty())
-		return makeErrorResponse(204, "No Content", server, clientSocket);
+		return makeResponse(204, "No Content", "text/plain", "");
 	else if (contentType.find("text/plain") != std::string::npos)
 		return handleTextPost(req, maxBodySize);
 	else if (contentType.find("multipart/form-data") != std::string::npos)

--- a/srcs/server/Server.cpp
+++ b/srcs/server/Server.cpp
@@ -155,8 +155,11 @@ void	Server::processRequest(int clientSocket, const std::string& clientRequest)
 	request.printRequest();
 	OutgoingData *response;
 
-	std::cerr << " METHOD: " << request.get_method() << std::endl;
-	if (request.get_method() == "GET")
+	if (request.getUri().empty() || request.get_method().empty())
+		response = Response::makeErrorResponse(400, "Bad Request", request.getServer(), clientSocket);
+	else if (request.getHttpVersion() != "HTTP/1.1")
+		response = Response::makeErrorResponse(505, "HTTP Version Not Supported", request.getServer(), clientSocket);
+	else if (request.get_method() == "GET")
 		response = Response::handleGet(request, clientSocket, *this);
 	else if (request.get_method() == "POST")
 		response = Response::handlePost(request, clientSocket);

--- a/srcs/server/Server.cpp
+++ b/srcs/server/Server.cpp
@@ -244,6 +244,12 @@ void	Server::handleClientEvent(int clientSocket, uint32_t event)
 					sendResponse(clientSocket, Response::makeResponse(413, "Entity Too Large", "text/plain", "Maximum headers size exceeded."));
 					//closeConnection(clientSocket, event);
 				}
+				else
+				{
+					const t_server& server = *_sockets[clientSocket].server;
+					OutgoingData* response = Response::makeErrorResponse(400, "Bad Request", server, clientSocket);
+					sendResponse(clientSocket, response);
+				}
 			}
 			else if (bytesRead == 0)
 			{

--- a/srcs/server/Server.cpp
+++ b/srcs/server/Server.cpp
@@ -157,6 +157,8 @@ void	Server::processRequest(int clientSocket, const std::string& clientRequest)
 
 	if (request.getUri().empty() || request.get_method().empty())
 		response = Response::makeErrorResponse(400, "Bad Request", request.getServer(), clientSocket);
+	else if (request.get_method() == "INVALID")
+		response = Response::makeErrorResponse(405, "Method Not Allowed", request.getServer(), clientSocket);
 	else if (request.getHttpVersion() != "HTTP/1.1")
 		response = Response::makeErrorResponse(505, "HTTP Version Not Supported", request.getServer(), clientSocket);
 	else if (request.get_method() == "GET")
@@ -166,7 +168,7 @@ void	Server::processRequest(int clientSocket, const std::string& clientRequest)
 	else if (request.get_method() == "DELETE")
 		response = Response::handleDelete(request, clientSocket);
 	else
-		response = Response::makeErrorResponse(405, "Method Not Allowed", request.getServer(), clientSocket);
+		response = Response::makeErrorResponse(400, "Bad Request", request.getServer(), clientSocket);
 	sendResponse(clientSocket, response);
 }
 


### PR DESCRIPTION
Changed processRequest to return correct response code (400, 405 and 204) for bad and weird requests.

The server now checks for missing headers, wrong HTTP version, and behaves accurately for POST request with no content. THomas and I decided to default to returning 204 regardless of the path of the POST request because lazy xd